### PR TITLE
Nishanthkarthik patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ User: user Password: user
 
 User: root Password: root 
 
-* [Creating Intel Galileo Debian build server.](GalileoDebianBuildNotes.txt)
+* [Creating Intel Galileo Debian build server.](Documentation/GalileoDebianBuildNotes.txt)
 
 * [Installing C# mono on Galileo board](http://galileo.codeplex.com)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ User: user Password: user
 
 User: root Password: root 
 
-* [Creating Intel Galileo Debian build server.](//Documentation/GalileoDebianBuildNotes.txt)
+* [Creating Intel Galileo Debian build server.](GalileoDebianBuildNotes.txt)
 
 * [Installing C# mono on Galileo board](http://galileo.codeplex.com)


### PR DESCRIPTION
The documentation page wasn't linked properly. So, according to http://stackoverflow.com/questions/7653483/github-relative-link-in-markdown-file I changed the Url.
